### PR TITLE
Update AksEdgeQuickStartForAio.ps1

### DIFF
--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -105,7 +105,7 @@ $aksedgeConfig = @"
         {
             "LinuxNode": {
                 "CpuCount": 8,
-                "MemoryInMB": 8192,
+                "MemoryInMB": 16384,
                 "DataSizeInGB": 30,
                 "LogSizeInGB": 4
             }


### PR DESCRIPTION
The docs said AIO has been validated with a 16G machine for AKS-EE

https://learn.microsoft.com/en-us/azure/iot-operations/get-started/overview-iot-operations#validated-environments