### PR TITLE
Install connectedk8s AZ CLI extension if needed

### DIFF
--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -54,6 +54,9 @@ if ( $null -eq $azureLogin){
     exit -1
 }
 
+# Ensure `connectedk8s` az cli extension is installed and up to date.
+az extension add --upgrade --name connectedk8s -y
+
 $installDir = $((Get-Location).Path)
 $productName = "AKS Edge Essentials - K3s"
 $networkplugin = "flannel"


### PR DESCRIPTION
This update will do the following:

- Install or update the `connectedk8s` AZ CLI extension which is required when using `az connectedk8s` commands.

This update fixes the following:

- Unexpected script *hanging* on connecting the new cluster to Azure Arc.

Currently, if the machine that is running this script does not have the `connectedk8s` extension installed when the script attempts to connect the cluster to Azure Arc the end user will experience the script *hanging*. This is due to AZ CLI prompting the user to enter `y` to install this extension however, std out is piped to null which prevents the end user from seeing this message.