### PR TITLE
AksEdgeQuickStartForAio.ps1 continues on failed VM deployment

### DIFF
--- a/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
+++ b/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
@@ -1140,7 +1140,6 @@ function Start-AideWorkflow {
         if (!(Test-AideVmSwitch -Create)) { return $false } #create switch if specified
         # We are here.. all is good so far. Validate and deploy aksedge
         $result = Invoke-AideDeployment
-        Write-Host "$result--- should return false"
         return $result
     }
     return $true

--- a/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
+++ b/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
@@ -1116,7 +1116,6 @@ function Start-AideWorkflow {
                 return $false
             }
         } else {
-            Write-Host "-------------------going to outer else block-------------------"
             $jsonFile = (Resolve-Path -Path $jsonFile).Path
             $retval = Set-AideUserConfig -jsonFile $jsonFile # validate later after creating the switch
             if (!$retval) {

--- a/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
+++ b/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
@@ -1139,8 +1139,7 @@ function Start-AideWorkflow {
     } else {
         if (!(Test-AideVmSwitch -Create)) { return $false } #create switch if specified
         # We are here.. all is good so far. Validate and deploy aksedge
-        $result = Invoke-AideDeployment
-        return $result
+        return Invoke-AideDeployment
     }
     return $true
 }

--- a/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
+++ b/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
@@ -1116,6 +1116,7 @@ function Start-AideWorkflow {
                 return $false
             }
         } else {
+            Write-Host "-------------------going to outer else block-------------------"
             $jsonFile = (Resolve-Path -Path $jsonFile).Path
             Set-AideUserConfig -jsonFile $jsonFile # validate later after creating the switch
         }

--- a/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
+++ b/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
@@ -1118,7 +1118,11 @@ function Start-AideWorkflow {
         } else {
             Write-Host "-------------------going to outer else block-------------------"
             $jsonFile = (Resolve-Path -Path $jsonFile).Path
-            Set-AideUserConfig -jsonFile $jsonFile # validate later after creating the switch
+            $retval = Set-AideUserConfig -jsonFile $jsonFile # validate later after creating the switch
+            if (!$retval) {
+                Write-Host "Error: $jsonFile incorrect after creating switch" -ForegroundColor Red
+                return $false
+            }
         }
     }
 

--- a/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
+++ b/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
@@ -1135,7 +1135,9 @@ function Start-AideWorkflow {
     } else {
         if (!(Test-AideVmSwitch -Create)) { return $false } #create switch if specified
         # We are here.. all is good so far. Validate and deploy aksedge
-        return Invoke-AideDeployment
+        $result = Invoke-AideDeployment
+        Write-Host "$result--- should return false"
+        return $result
     }
     return $true
 }

--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
@@ -181,9 +181,9 @@ if ($azcfg.Auth.Password) {
 # Download, install and deploy AKS EE 
 Write-Host "Step 3: Download, install and deploy AKS Edge Essentials"
 # invoke the workflow, the json file already updated above.
-$retval = Start-AideWorkflow -jsonFile $aidejson
-Write-Host "it should return false --- $retval"
-if ($retval) {
+$aidresult = Start-AideWorkflow -jsonFile $aidejson
+Write-Host "it should return false --- $aidresult"
+if ($aidresult) {
     Write-Host "Deployment Successful. "
 } else {
     Write-Host -Message "Deployment failed" -Category OperationStopped -ForegroundColor Red

--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
@@ -182,7 +182,6 @@ if ($azcfg.Auth.Password) {
 Write-Host "Step 3: Download, install and deploy AKS Edge Essentials"
 # invoke the workflow, the json file already updated above.
 $aidresult = Start-AideWorkflow -jsonFile $aidejson
-Write-Host "it should return false --- $aidresult"
 if ($aidresult) {
     Write-Host "Deployment Successful. "
 } else {

--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
@@ -124,8 +124,8 @@ Start-Transcript -Path $transcriptFile
 
 Set-ExecutionPolicy Bypass -Scope Process -Force
 # Download the AksEdgeDeploy modules from Azure/AksEdge
-$fork ="mallineniuma"
-$branch="neeharika"
+$fork ="Azure"
+$branch="main"
 $url = "https://github.com/$fork/AKS-Edge/archive/$branch.zip"
 $zipFile = "AKS-Edge-$branch.zip"
 $workdir = "$installDir\AKS-Edge-$branch"

--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
@@ -124,8 +124,8 @@ Start-Transcript -Path $transcriptFile
 
 Set-ExecutionPolicy Bypass -Scope Process -Force
 # Download the AksEdgeDeploy modules from Azure/AksEdge
-$fork ="Azure"
-$branch="main"
+$fork ="mallineniuma"
+$branch="neeharika"
 $url = "https://github.com/$fork/AKS-Edge/archive/$branch.zip"
 $zipFile = "AKS-Edge-$branch.zip"
 $workdir = "$installDir\AKS-Edge-$branch"

--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
@@ -181,8 +181,8 @@ if ($azcfg.Auth.Password) {
 # Download, install and deploy AKS EE 
 Write-Host "Step 3: Download, install and deploy AKS Edge Essentials"
 # invoke the workflow, the json file already updated above.
-$aidresult = Start-AideWorkflow -jsonFile $aidejson
-if ($aidresult) {
+$retval = Start-AideWorkflow -jsonFile $aidejson
+if ($retval) {
     Write-Host "Deployment Successful. "
 } else {
     Write-Host -Message "Deployment failed" -Category OperationStopped -ForegroundColor Red

--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
@@ -182,6 +182,7 @@ if ($azcfg.Auth.Password) {
 Write-Host "Step 3: Download, install and deploy AKS Edge Essentials"
 # invoke the workflow, the json file already updated above.
 $retval = Start-AideWorkflow -jsonFile $aidejson
+Write-Host "it should return false --- $retval"
 if ($retval) {
     Write-Host "Deployment Successful. "
 } else {


### PR DESCRIPTION
The return value from the function Start-AideWorkflow is "True False" 
<img width="551" alt="image" src="https://github.com/Azure/AKS-Edge/assets/129788221/fe9f782b-6726-42d2-b2fe-4371517a4790">

That is the reason after erroring out it doesnt exit instead it proceeds to the next step, After making the required changes in the Start-AideWorkflow it is now returning false and hence it errors and exits out 
<img width="575" alt="image" src="https://github.com/Azure/AKS-Edge/assets/129788221/719dbbbd-bb69-4b56-9f2c-35c11d06b6a6">

<img width="522" alt="image" src="https://github.com/Azure/AKS-Edge/assets/129788221/89638561-f39d-4c0e-87fa-84737cb586e2">
