### PR TITLE
add additional iptables rules for ESA

### DIFF
--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -285,7 +285,21 @@ try {
     }
     else {
         Write-Host "iptable rule exists, skip configuring iptable rules..."
-    } 
+    }
+
+    # Add additional firewall rules
+    $dports = @(10124, 8420, 2379, 50051)
+    foreach($port in $dports)
+    {
+        $iptableRulesExist = Invoke-AksEdgeNodeCommand -NodeType "Linux" -command "sudo iptables-save | grep -- '-m tcp --dport $port -j ACCEPT'" -ignoreError
+        if ( $null -eq $iptableRulesExist ) {
+            Invoke-AksEdgeNodeCommand -NodeType "Linux" -command "sudo iptables -A INPUT -p tcp --dport $port -j ACCEPT"
+            Write-Host "Updated runtime iptable rules for port $port"
+        }
+        else {
+            Write-Host "iptable rule exists, skip configuring iptable rule for port $port..."
+        }
+    }
 }
 catch {
     Write-Host "Error: iptable rule update failed" -ForegroundColor Red

--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -16,7 +16,7 @@ param(
     [string] $Tag
 )
 #Requires -RunAsAdministrator
-New-Variable -Name gAksEdgeQuickStartForAioVersion -Value "1.0.240307.1330" -Option Constant -ErrorAction SilentlyContinue
+New-Variable -Name gAksEdgeQuickStartForAioVersion -Value "1.0.240419.1300" -Option Constant -ErrorAction SilentlyContinue
 
 # Specify only AIO supported regions
 New-Variable -Option Constant -ErrorAction SilentlyContinue -Name arcLocations -Value @(


### PR DESCRIPTION
- A few `iptables` commands we need to run to work with ACStor:
iptables -A INPUT -p tcp --dport 10124 -j ACCEPT
iptables -A INPUT -p tcp --dport 8420 -j ACCEPT
iptables -A INPUT -p tcp --dport 2379 -j ACCEPT
iptables -A INPUT -p tcp --dport 50051 -j ACCEPT