### PR TITLE
enable workloadidentity for AIO

### DIFF
--- a/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
+++ b/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
@@ -280,7 +280,10 @@ function UpgradeJsonFormat {
     #upgrade from public preview format to GA format
     $edgeCfg = $jsonObj.AksEdgeConfig
 
-    if ($edgeCfg.SchemaVersion -gt "1.4") {
+    $version = [int[]]$edgeCfg.SchemaVersion.Split(".")
+    $majorVersion = [int]$version[0]
+    $minorVersion = [int]$version[1]
+    if (($majorVersion -gt 1) -or ($majorVersion -eq 1 -and $minorVersion -gt 4)) {
         if (($azCfg.Auth.Password) -and ([string]::IsNullOrEmpty($($edgeCfg.Arc.ClientSecret)))) {
             #Copy over the Azure parameters to Arc section
             $edgeCfg | Add-Member -MemberType NoteProperty -Name 'Arc' -Value $arcdata -Force

--- a/tools/modules/AksEdgeDeploy/README.md
+++ b/tools/modules/AksEdgeDeploy/README.md
@@ -16,7 +16,7 @@ The `Start-AideWorkflow` function in the modole does the following:
 
     ```json
     {
-        "SchemaVersion": "1.1",
+        "SchemaVersion": "1.2",
         "Version": "1.0",
         "AksEdgeProduct" : "AKS Edge Essentials - K3s",
         "AksEdgeConfig": {
@@ -50,7 +50,8 @@ The `Start-AideWorkflow` function in the modole does the following:
             "TenantId":"",
             "ResourceGroupName": "aksedge-rg",
             "ServicePrincipalName" : "aksedge-sp",
-            "Location" : "EastUS"
+            "Location" : "EastUS",
+            "EnableWorkloadIdentity": true
         }
     }
     ```
@@ -81,6 +82,7 @@ Find below the details of the supported parameters in the json file.
 || CustomLocationOID | Optional | GUID | ObjectID for the custom location resource provider  |
 || `Auth`.ServicePrincipalId |Mandatory | GUID | Specify service principal appID to use|
 || `Auth`.Password |Mandatory| String | Specify the password (in clear) |
+|| EnableWorkloadIdentity |Optional| Boolean | Enable secure workload access to azure resource |
 |InstallOptions| InstallPath | Optional | String |  Path to install the product  |
 || VhdxPath | Optional | String | Path to store the vhdx files  |
 |VSwitch| Name | Optional | String | Name for the external switch, mandatory for ScalableCluster|

--- a/tools/modules/AksEdgeDeploy/aide-ucschema.json
+++ b/tools/modules/AksEdgeDeploy/aide-ucschema.json
@@ -6,7 +6,7 @@
     "properties": {
         "SchemaVersion": {
             "type": "string",
-            "default": "1.1",
+            "default": "1.2",
             "description": "Version of the schema/format of the json"
         },
         "Version": {
@@ -72,6 +72,9 @@
                             "description": "Password corresponding to ServicePrincipalId to onboard Arc-enabled Server/Kubernetes"
                         }
                     }
+                },
+                "EnableWorkloadIdentity": {
+                    "type": "boolean"
                 }
             }
         },

--- a/tools/modules/AksEdgeDeploy/aide-userconfig.puml
+++ b/tools/modules/AksEdgeDeploy/aide-userconfig.puml
@@ -21,7 +21,7 @@ jsonDiagram {
 </style>
 #highlight "SchemaVersion"
 {
-    "SchemaVersion":"1.1",
+    "SchemaVersion":"1.2",
     "Version":"1.0",
     "AksEdgeProduct" : [
                 "AKS Edge Essentials - K8s",
@@ -40,7 +40,8 @@ jsonDiagram {
         "Auth": {
             "ServicePrincipalId" : "GUID",
             "Password" : "String"
-        }
+        },
+        "EnableWorkloadIdentity" : "Boolean"
     }
     ,
     "InstallOptions":{

--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -13,10 +13,87 @@ param(
     [ValidateNotNullOrEmpty()]
     [String] $ClusterName,
     [Switch] $UseK8s=$false,
-    [string] $Tag
+    [string] $Tag,
+    # Temporary params for private bits
+    [Parameter(Mandatory=$true)]
+    [string] $connectedK8sPrivateWhlPath,
+    [Parameter(Mandatory=$true)]
+    [string] $helmPath
 )
 #Requires -RunAsAdministrator
 New-Variable -Name gAksEdgeQuickStartForAioVersion -Value "1.0.240419.1300" -Option Constant -ErrorAction SilentlyContinue
+
+function Restart-ApiServer
+{
+param(
+    [Parameter(Mandatory=$true)]
+    [string] $serviceAccountIssuer
+)
+
+    Write-Host "serviceAccountIssuer = $serviceAccountIssuer"
+    Invoke-AksEdgeNodeCommand -command "sudo cat /var/.eflow/config/k3s/k3s-config.yml | tee /home/aksedge-user/k3s-config.yml | tee /home/aksedge-user/k3s-config.yml.working > /dev/null"
+    Invoke-AksEdgeNodeCommand -command "sudo sed -i 's|service-account-issuer.*|service-account-issuer=$serviceAccountIssuer|' /home/aksedge-user/k3s-config.yml"
+    Invoke-AksEdgeNodeCommand -command "sudo cp /home/aksedge-user/k3s-config.yml /var/.eflow/config/k3s/k3s-config.yml"
+    Invoke-AksEdgeNodeCommand -command "sudo systemctl restart k3s.service"
+
+    Start-Sleep -Seconds 10
+}
+
+function New-ConnectedCluster
+{
+param(
+    [Parameter(Mandatory=$true)]
+    [string] $resourceGroup,
+    [Parameter(Mandatory=$true)]
+    [string] $location,
+    [Parameter(Mandatory=$true)]
+    [string] $clusterName,
+    [Parameter(Mandatory=$true)]
+    [string] $subscriptionId,
+    [Parameter(Mandatory=$true)]
+    [string] $connectedK8sPrivateWhlPath
+)
+
+    Write-Host "New-ConnectedCluster"
+    $tags = @("SKU=AKSEdgeEssentials")
+    $modVersion = (Get-Module AksEdge).Version
+    if ($modVersion) { 
+        $tags += @("Version=$modVersion")
+    }
+    $infra = Get-AideInfra
+    if ($infra) { 
+        $tags += @("Infra=$infra")
+    }
+    $clusterid = $(kubectl get configmap -n aksedge aksedge -o jsonpath="{.data.clustername}")
+    if ($clusterid) { 
+        $tags += @("ClusterId=$clusterid")
+    }
+
+    az extension remove --name connectedk8s
+    az extension add --source $connectedK8sPrivateWhlPath --allow-preview true -y
+    $env:HELMREGISTRY="azurearcfork8sdev.azurecr.io/merge/private/azure-arc-k8sagents:0.1.14275-private"
+    az connectedk8s connect -g $resourceGroup -n $clusterName --subscription $subscriptionId --tags $tags --disable-auto-upgrade --enable-oidc-issuer
+
+    $serviceAccountIssuer = az connectedk8s show-issuer-url
+    if ([string]::IsNullOrEmpty($serviceAccountIssuer))
+    {
+        Write-Host "az connectedk8s show-issuer-url returned empty URL!"
+        $jsonString = & kubectl get signingkeys.clusterconfig.azure.com -n azure-arc signingkey -o json
+        $jsonObj = $jsonString | ConvertFrom-Json
+        $serviceAccountIssuer = $jObj.status.clusterIssuerUrl
+        if ([string]::IsNullOrEmpty($serviceAccountIssuer))
+        {
+            throw "Invalid, empty IssuerUrl!"
+        }
+    }
+
+    Write-Host "serviceAccountIssuer = $serviceAccountIssuer"
+    Restart-ApiServer -serviceAccountIssuer $serviceAccountIssuer
+
+    & $helmPath repo add azure-workload-identity https://azure.github.io/azure-workload-identity/charts
+    & $helmPath repo update
+    & $helmPath install workload-identity-webhook azure-workload-identity/workload-identity-webhook --namespace azure-workload-identity-system --create-namespace --set azureTenantID="$tenantId"
+}
 
 # Specify only AIO supported regions
 New-Variable -Option Constant -ErrorAction SilentlyContinue -Name arcLocations -Value @(
@@ -71,7 +148,7 @@ $aideuserConfig = @"
     "SchemaVersion": "1.1",
     "Version": "1.0",
     "AksEdgeProduct": "$productName",
-    "AksEdgeProductUrl": "https://download.microsoft.com/download/3/d/7/3d7b3eea-51c2-4a2c-8405-28e40191e715/AksEdge-K3s-1.26.10-1.6.384.0.msi",
+    "AksEdgeProductUrl": "C:\\Users\\Public\\msi\\K3s.msi",
     "Azure": {
         "SubscriptionName": "",
         "SubscriptionId": "$SubscriptionId",
@@ -80,6 +157,7 @@ $aideuserConfig = @"
         "ServicePrincipalName": "aksedge-sp",
         "Location": "$Location",
         "CustomLocationOID":"",
+        "EnableWorkloadIdentity": true,
         "Auth":{
             "ServicePrincipalId":"",
             "Password":""
@@ -90,7 +168,7 @@ $aideuserConfig = @"
 "@
 $aksedgeConfig = @"
 {
-    "SchemaVersion": "1.9",
+    "SchemaVersion": "1.14",
     "Version": "1.0",
     "DeploymentType": "SingleMachineCluster",
     "Init": {
@@ -133,8 +211,8 @@ Start-Transcript -Path $transcriptFile
 
 Set-ExecutionPolicy Bypass -Scope Process -Force
 # Download the AksEdgeDeploy modules from Azure/AksEdge
-$fork ="Azure"
-$branch="main"
+$fork ="jagadishmurugan"
+$branch="users/jagamu/Bugfix-EdgeConfigVersionCompare"
 $url = "https://github.com/$fork/AKS-Edge/archive/$branch.zip"
 $zipFile = "AKS-Edge-$branch.zip"
 $workdir = "$installDir\AKS-Edge-$branch"
@@ -166,7 +244,6 @@ Set-Content -Path $aksedgejson -Value $aksedgeConfig -Force
 
 $aksedgeShell = (Get-ChildItem -Path "$workdir" -Filter AksEdgeShell.ps1 -Recurse).FullName
 . $aksedgeShell
-
 # Download, install and deploy AKS EE 
 Write-Host "Step 2: Download, install and deploy AKS Edge Essentials" -ForegroundColor Cyan
 # invoke the workflow, the json file already updated above.
@@ -204,20 +281,7 @@ az provider register -n "Microsoft.DeviceRegistry"
 # Arc-enable the Kubernetes cluster
 Write-Host "Arc enable the kubernetes cluster $ClusterName" -ForegroundColor Cyan
 
-$tags = @("SKU=AKSEdgeEssentials")
-$modVersion = (Get-Module AksEdge).Version
-if ($modVersion) { 
-    $tags += @("Version=$modVersion") 
-}
-$infra = Get-AideInfra
-if ($infra) { 
-    $tags += @("Infra=$infra") 
-}
-$clusterid = $(kubectl get configmap -n aksedge aksedge -o jsonpath="{.data.clustername}")
-if ($clusterid) { 
-    $tags += @("ClusterId=$clusterid") 
-}
-az connectedk8s connect -n $ClusterName -l $Location -g $ResourceGroupName --subscription $SubscriptionId --tags $tags | Out-Null
+New-ConnectedCluster -clusterName $ClusterName -location $Location -resourcegroup $ResourceGroupName -subscriptionId $SubscriptionId -connectedK8sPrivateWhlPath $connectedK8sPrivateWhlPath
 
 # Enable custom location support on your cluster using az connectedk8s enable-features command
 Write-Host "Associate Custom location with $ClusterName cluster"


### PR DESCRIPTION
**Verification steps:**
1. Download connectedk8s private bits containing implementation for --enable-oidc-issue flags
2. Download & install helm
3. .\aksEdgeQuickStartForAio.ps1 -Location "eastus" -SubscriptionId <sub-id> -TenantId "72f988bf-86f1-41af-91ab-2d7cd011db47" -ClusterName "<cluster-name>" -ResourceGroupName aksee-arc-testframework  -connectedK8sPrivateWhlPath "path-to-connectedk8s-1.6.8_private-py2.py3-none-any.whl" -helmPath "path-to-helm.exe" -Tag "test-v0.2"



Note: This change is not intended to be committed as it uses private bits. Once the prod bits from Arc team is available, we should make minor modifications to use the correct arc module versions and change repo/tag back point to Azure (main fork).