### PR TITLE
Ensure k8s msi is used when -UseK8s switch is used

### DIFF
--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -13,6 +13,7 @@ param(
     [ValidateNotNullOrEmpty()]
     [String] $ClusterName,
     [String] $CustomLocationOid,
+    # k8s is not fully validated. Please refer AIO documentation for validated platforms
     [Switch] $UseK8s=$false,
     [string] $Tag
 )

--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -140,9 +140,12 @@ az extension add --upgrade --name connectedk8s -y
 $installDir = $((Get-Location).Path)
 $productName = "AKS Edge Essentials - K3s"
 $networkplugin = "flannel"
+$productUrl = "https://download.microsoft.com/download/9/d/b/9db70435-27fc-4feb-8792-04444d585526/AksEdge-K3s-1.28.3-1.7.639.0.msi"
 if ($UseK8s) {
     $productName ="AKS Edge Essentials - K8s"
     $networkplugin = "calico"
+    # Setting URL to empty string, so K8s msi will be selected
+    $productUrl = ""
 }
 
 # Here string for the json content
@@ -151,7 +154,7 @@ $aideuserConfig = @"
     "SchemaVersion": "1.1",
     "Version": "1.0",
     "AksEdgeProduct": "$productName",
-    "AksEdgeProductUrl": "https://download.microsoft.com/download/9/d/b/9db70435-27fc-4feb-8792-04444d585526/AksEdge-K3s-1.28.3-1.7.639.0.msi",
+    "AksEdgeProductUrl": "$productUrl",
     "Azure": {
         "SubscriptionName": "",
         "SubscriptionId": "$SubscriptionId",


### PR DESCRIPTION
Ensure k8s msi is used when -UseK8s switch is used. Currently k3s msi is used since productUrl is hardcoded.