### PR TITLE
feb release arc connection by default quickstart, aio

### DIFF
--- a/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
+++ b/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
@@ -912,7 +912,9 @@ function Invoke-AideDeployment {
     Write-Verbose "$aksedgeDeployParams"
     Write-Host "Starting AksEdge VM deployment..."
     $retval = New-AksEdgeDeployment -JsonConfigString $aksedgeDeployParams
-
+    if ($retval -ieq "arc parameters not set or invalid") {
+        $retval = "OK"
+    }
     if ($retval -ieq "OK") {
         Write-Host "* AksEdge VM deployment successfull." -ForegroundColor Green
     } else {


### PR DESCRIPTION
Added a check to make sure deployment doesnt fail when arc parameters are not set or invalid.
 
Testing 
When config file has errors in arc parameters - k3s
 
![image](https://github.com/user-attachments/assets/de3dc692-1cf5-4a2f-8abd-acb601bf7bad)
![image](https://github.com/user-attachments/assets/cac107f8-7ed5-40e2-bac7-56ca0c134f8c)
 
When config file has errors in arc parameters - k8s
 
![image](https://github.com/user-attachments/assets/3287e717-56a2-4777-a34a-be7722484303)
 
![image](https://github.com/user-attachments/assets/4a6d059b-1dc4-4081-9291-c7515f4f1639)
