### PR TITLE
add UseBasicParsing option to Invoke-WebRequest

### DIFF
--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStart.ps1
@@ -139,7 +139,7 @@ Write-Host "Step 1 : Azure/AKS-Edge repo setup"
 
 if (!(Test-Path -Path "$installDir\$zipFile")) {
     try {
-        Invoke-WebRequest -Uri $url -OutFile $installDir\$zipFile
+        Invoke-WebRequest -Uri $url -OutFile $installDir\$zipFile -UseBasicParsing
     } catch {
         Write-Host "Error: Downloading Aide Powershell Modules failed" -ForegroundColor Red
         Stop-Transcript | Out-Null

--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -342,7 +342,7 @@ Write-Host "Step 1 : Azure/AKS-Edge repo setup" -ForegroundColor Cyan
 
 if (!(Test-Path -Path "$installDir\$zipFile")) {
     try {
-        Invoke-WebRequest -Uri $url -OutFile $installDir\$zipFile
+        Invoke-WebRequest -Uri $url -OutFile $installDir\$zipFile -UseBasicParsing
     } catch {
         Write-Host "Error: Downloading Aide Powershell Modules failed" -ForegroundColor Red
         Stop-Transcript | Out-Null


### PR DESCRIPTION
**RootCause**
Script fails because Invoke-WebRequest fails to download because of a well known dependency on InternetExplorer - Invoke-WebRequest uses Internet Explorer and requires it be opened at least once.
For more details, refer https://stackoverflow.com/questions/46675646/invoke-webrequest-error?noredirect=1

**Workaround**
Open InternetExplorer and then run the script. This is unlikely to be hit in most cases except on a fairly new/unused machine with LTSC installed

**Solution**
Use Invoke-WebRequest with -UseBasicParsing option 