### PR TITLE
Download msi upon rerun

### DIFF
--- a/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psd1
+++ b/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'AksEdgeDeploy.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.0.250304.0900'
+    ModuleVersion     = '1.0.250318.0900'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
+++ b/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
@@ -749,9 +749,7 @@ function Install-AideMsi {
     } else {
         $ProgressPreference = 'SilentlyContinue'
         try {
-            if (-not (Test-Path $msiFile)) {
-                Invoke-WebRequest $url -OutFile $msiFile -UseBasicParsing
-            }
+            Invoke-WebRequest $url -OutFile $msiFile -UseBasicParsing
         } catch {
             Write-Host "failed to download from $url"
             Remove-Item $msiFile -Force -ErrorAction SilentlyContinue
@@ -762,9 +760,7 @@ function Install-AideMsi {
         if($windowsRequired) {
             $argList = '/I AksEdge.msi ADDLOCAL=CoreFeature,WindowsNodeFeature /passive '
             try {
-                if (-not (Test-Path $winFile)) {
-                    Invoke-WebRequest $winUrl -OutFile $winFile -UseBasicParsing
-                }
+                Invoke-WebRequest $winUrl -OutFile $winFile -UseBasicParsing
                 if (Test-Path $winFile) {
                     Write-Host "Unzip WindowsInstallFiles.."
                     Expand-ArchiveLocal $winFile .

--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -349,7 +349,7 @@ Start-Transcript -Path $transcriptFile
 
 Set-ExecutionPolicy Bypass -Scope Process -Force
 # Download the AksEdgeDeploy modules from Azure/AksEdge
-$fork ="Azure"
+$fork ="philmon-msft"
 $branch="main"
 $url = "https://github.com/$fork/AKS-Edge/archive/$branch.zip"
 $zipFile = "AKS-Edge-$branch.zip"

--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -349,7 +349,7 @@ Start-Transcript -Path $transcriptFile
 
 Set-ExecutionPolicy Bypass -Scope Process -Force
 # Download the AksEdgeDeploy modules from Azure/AksEdge
-$fork ="philmon-msft"
+$fork ="Azure"
 $branch="main"
 $url = "https://github.com/$fork/AKS-Edge/archive/$branch.zip"
 $zipFile = "AKS-Edge-$branch.zip"


### PR DESCRIPTION
This is a fix to handle re-running the aio quickstart script after an incomplete download of the msi due to some interruption.
I was able to repro this issue and confirm it was fixed after including this change. A similar line change was also done for the windows zip file, albeit not necessary for aio.