### PR TITLE
Update azure-vote-front and azure-vote-bank container image registry

### DIFF
--- a/samples/others/linux-sample.yaml
+++ b/samples/others/linux-sample.yaml
@@ -17,7 +17,7 @@ spec:
         "kubernetes.io/os": linux
       containers:
       - name: azure-vote-back
-        image: mcr.microsoft.com/oss/bitnami/redis:6.0.8
+        image: azurek8ssamples.azurecr.io/marketplaceimages/azure-vote-back:latest
         env:
         - name: ALLOW_EMPTY_PASSWORD
           value: "yes"
@@ -58,7 +58,7 @@ spec:
         "kubernetes.io/os": linux
       containers:
       - name: azure-vote-front
-        image: mcr.microsoft.com/azuredocs/azure-vote-front:v1
+        image: azurek8ssamples.azurecr.io/marketplaceimages/azure-vote-front:latest
         ports:
         - containerPort: 80
         resources:


### PR DESCRIPTION
This PR updates the registry for the container images refenced in the linux-sample.yaml manifest file to address issue #245, where the azure-vote-front image is not found on mcr.

Change was tested locally on k8s-1.18.868.0. Both pods and services are up and running for azure-vote-front and azure-vote-back.