### PR TITLE
adding SkipArc json flag for aio quickstart deployment

### DIFF
--- a/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
+++ b/tools/modules/AksEdgeDeploy/AksEdgeDeploy.psm1
@@ -310,6 +310,8 @@ function UpgradeJsonFormat {
         $endip = $edgeCfg.Network.ServiceIPRangeEnd
         $newEdgeConfig.Init.ServiceIPRangeSize = ($endip.Split(".")[3]) - ($startip.Split(".")[3])
     }
+    #adding SkipArc flag
+    $newEdgeConfig.SkipArc = $true
     #arc section
     $newEdgeConfig | Add-Member -MemberType NoteProperty -Name 'Arc' -Value $arcdata -Force
     #network section
@@ -914,10 +916,7 @@ function Invoke-AideDeployment {
     Write-Verbose "$aksedgeDeployParams"
     Write-Host "Starting AksEdge VM deployment..."
     $retval = New-AksEdgeDeployment -JsonConfigString $aksedgeDeployParams
-    
-    if ($retval -ieq "Azure Arc parameters not set or invalid") {
-        $retval = "OK"
-    }
+
     if ($retval -ieq "OK") {
         Write-Host "* AksEdge VM deployment successfull." -ForegroundColor Green
     } else {


### PR DESCRIPTION
Removed the previously existing check for parameters not set or invalid 
assigned SkipArc config flag to true and run deployment function with the config file 