### PR TITLE
Add Location variable to ConnectAksEdgeArc for AksEdgeQuickStartForAi…

### DIFF
--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -383,6 +383,7 @@ param (
 
     $SubscriptionId = $aideuserConfig.Azure.SubscriptionId
     $ResourceGroupName = $aideuserConfig.Azure.ResourceGroupName
+    $Location = $aideuserConfig.Azure.Location
     $ClusterName = $aksedgeConfig.Arc.ClusterName
 
     # Set the azure subscription


### PR DESCRIPTION
…o.ps1

The resource group failed to create after at line 399, because $Location was not set