### PR TITLE
Add distribution argument for k3s in script

### DIFF
--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -149,6 +149,7 @@ param(
     $k8sConnectArgs += @("--subscription", $arcArgs.SubscriptionId)
     $k8sConnectArgs += @("--tags", $tags)
     $k8sConnectArgs += @("--disable-auto-upgrade")
+    $k8sConnectArgs += @("--distribution", "aks_edge_k3s")
     if ($null -ne $proxyArgs)
     {
         if (-Not [string]::IsNullOrEmpty($proxyArgs.Http))


### PR DESCRIPTION
This PR updates the AIO AKS Edge Essentials QuickStart script to explicitly declare the Kubernetes distribution as AKS Edge Essentials (K3s) when connecting the cluster to Azure Arc, ensuring Arc registration uses the correct distribution metadata.

Changes:

Add --distribution aks_edge_k3s to the az connectedk8s connect argument list in the AIO QuickStart flow